### PR TITLE
Export the Plugin (entrypoint) directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean:dist": "rimraf -rf dist",
-    "tsc": "npm run clean:dist && tsc -d -t es5",
+    "tsc": "npm run clean:dist && tsc -d -w",
     "test": "ts-node node_modules/tape/bin/tape 'test/**/*.tape.ts' | tap-spec",
     "typings": "typings install"
   },
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/empirefox/fa-tool#readme",
   "dependencies": {
+    "markdown-it": "*",
     "markdown-it-regexp": "*"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,2 @@
-export * from './fa';
-export * from './stack-fa';
-export * from './parse';
-export * from './render';
-export * from './extract';
+import { markdownItPlugin } from './render';
+module.exports = markdownItPlugin;

--- a/test/format.tape.ts
+++ b/test/format.tape.ts
@@ -1,5 +1,5 @@
 import test = require('tape');
-import { format } from '../src';
+import { format } from '../src/parse';
 
 test('format test', t => {
   t.plan(6);

--- a/test/markdown-it-plugin.tape.ts
+++ b/test/markdown-it-plugin.tape.ts
@@ -1,0 +1,38 @@
+import test = require('tape');
+import markdownIt = require('markdown-it');
+import plugin = require('../src/index');
+
+declare global {
+  interface String {
+    workaround(): string;
+  }
+}
+
+String.prototype.workaround = function (this : string) {
+  var s = this;
+
+  // See https://github.com/rlidwka/markdown-it-regexp/issues/4
+  return `<p>${s}</p>\n`;
+};
+
+test('plugin test', t => {
+
+  const md = markdownIt();
+  md.use(plugin);
+
+  t.plan(3);
+  t.equal(md.render(':fa-ban:'), 
+`<i class="fa fa-ban"></i>`.workaround());
+  
+  t.equal(md.render(':fa-ban---camera--lg:'), 
+`<span class="fa-lg fa-stack">
+  <i class="fa fa-ban fa-stack-2x"></i>
+  <i class="fa fa-camera fa-stack-1x"></i>
+</span>`.workaround());
+
+  t.equal(md.render(':fa-ban--90--v--danger-----camera--lg--left--180--h--success-----x:'), 
+`<span class="fa-lg fa-pull-left fa-stack">
+  <i class="fa fa-camera fa-flip-horizontal fa-rotate-180 fa-stack-1x text-success"></i>
+  <i class="fa fa-ban fa-flip-vertical fa-rotate-90 fa-stack-2x text-danger"></i>
+</span>`.workaround());
+});

--- a/test/render.tape.ts
+++ b/test/render.tape.ts
@@ -1,5 +1,5 @@
 import test = require('tape');
-import { render } from '../src';
+import { render } from '../src/render';
 
 test('render test', t => {
   t.plan(7);


### PR DESCRIPTION
This will bring alignment with other Markdown-It plugins that don't require the developer to call .markdownPlugin when adding to Markdown-It. More so, it allows for looping of plugins and dynamically loading into Markdown-It.

All exports are still available via their internal module exports.

Added a new test to demostate the typical integration code. Note: a workaround is needed owing to an outstanding issue where <p> tags are wrapping the expected output.